### PR TITLE
[Fix] URL Config 파일로 숨기기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Config.xcconfig

--- a/walkingGO.xcodeproj/project.pbxproj
+++ b/walkingGO.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		06728F042D9CCA29000C88B8 /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 06728F032D9CCA29000C88B8 /* SDWebImageSwiftUI */; };
 		06884B212DAF2CCD00AE03BF /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 06884B202DAF2CCD00AE03BF /* Alamofire */; };
+		0693F0D92DB1170D00FD7FC5 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0693F0D82DB1170D00FD7FC5 /* Config.xcconfig */; };
 		06AA88D52DAF818A00DA4BFD /* SwiftKeychainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = 06AA88D42DAF818A00DA4BFD /* SwiftKeychainWrapper */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +34,7 @@
 		065E43412D7FBFAB00E005B6 /* walkingGO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = walkingGO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		065E43512D7FBFAD00E005B6 /* walkingGOTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = walkingGOTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		065E435B2D7FBFAE00E005B6 /* walkingGOUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = walkingGOUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0693F0D82DB1170D00FD7FC5 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -97,6 +99,7 @@
 		065E43382D7FBFAB00E005B6 = {
 			isa = PBXGroup;
 			children = (
+				0693F0D82DB1170D00FD7FC5 /* Config.xcconfig */,
 				065E43432D7FBFAB00E005B6 /* walkingGO */,
 				065E43542D7FBFAD00E005B6 /* walkingGOTests */,
 				065E435E2D7FBFAE00E005B6 /* walkingGOUITests */,
@@ -242,6 +245,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0693F0D92DB1170D00FD7FC5 /* Config.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,6 +424,7 @@
 		};
 		065E43662D7FBFAE00E005B6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0693F0D82DB1170D00FD7FC5 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -449,6 +454,7 @@
 		};
 		065E43672D7FBFAE00E005B6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0693F0D82DB1170D00FD7FC5 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/walkingGO/Info.plist
+++ b/walkingGO/Info.plist
@@ -2,11 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>URL</key>
+			<string>$(URL)</string>
+		</dict>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
 		<string>Pretendard-Medium.otf</string>
 		<string>Pretendard-SemiBold</string>
 	</array>
+	<key>URL</key>
+	<string>$(URL)</string>
 </dict>
 </plist>

--- a/walkingGO/Source/Features/Login/LoginView.swift
+++ b/walkingGO/Source/Features/Login/LoginView.swift
@@ -45,7 +45,7 @@ struct LoginView: View {
             if viewModel.successMessage != nil {
                 return Alert(
                     title: Text("로그인 성공"),
-                    message: Text(viewModel.successMessage ?? "로그인 성공!"),
+                    message: Text(viewModel.successMessage!),
                     dismissButton: .default(Text("확인")){
                         pathModel.paths.append(.menu)
                     }
@@ -53,7 +53,7 @@ struct LoginView: View {
             } else {
                 return Alert(
                     title: Text("로그인 실패"),
-                    message: Text(viewModel.errorMessage ?? ""),
+                    message: Text(viewModel.errorMessage!),
                     dismissButton: .default(Text("확인"))
                 )
             }

--- a/walkingGO/Source/Features/Login/LoginViewModel.swift
+++ b/walkingGO/Source/Features/Login/LoginViewModel.swift
@@ -20,8 +20,8 @@ class LoginViewModel: ObservableObject {
             "username": loginData.id,
             "password": loginData.password
         ]
-        
-        AF.request("http://localhost:8080/api/auth/login",method:.post,parameters: param,encoding: JSONEncoding.default)
+        let url = Config.url
+        AF.request("\(url)/api/auth/login",method:.post,parameters: param,encoding: JSONEncoding.default)
             .responseDecodable(of: LoginResponse.self){ response in
                 switch response.result {
                 case .success(let loginResponse):

--- a/walkingGO/Source/Features/SignUp/SignUpViewModel.swift
+++ b/walkingGO/Source/Features/SignUp/SignUpViewModel.swift
@@ -51,8 +51,9 @@ class SignUpViewModel: ObservableObject{
             "password":signUpData.password,
             "passwordConfirm":signUpData.passwordCheck
         ]
+        let url = Config.url
         
-        AF.request("http://localhost:8080/api/auth/signup",method: .post,parameters: param, encoding: JSONEncoding.default)
+        AF.request("\(url)/api/auth/signup",method: .post,parameters: param, encoding: JSONEncoding.default)
             .responseDecodable(of: SignUpResponse.self) { response in
                 switch response.result {
                 case .success(let signUpResponse):

--- a/walkingGO/Source/Service/Config.swift
+++ b/walkingGO/Source/Service/Config.swift
@@ -1,0 +1,17 @@
+//
+//  Config.swift
+//  walkingGO
+//
+//  Created by 박성민 on 4/17/25.
+//
+
+import Foundation
+
+enum Config {
+    static var url: String {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "URL") as? String else {
+            fatalError("❌ API_URL is missing in Info.plist")
+        }
+        return url
+    }
+}


### PR DESCRIPTION
### **🔹 작업 내용**

- URL을 Config.xcconfig로 숨겨주면서 받아오는 Config enum을 만들어주었습니다
- login, signup viewmodel에서 URL 숨기기

### **🔍 변경 사항 상세**

- **기존 방식 vs 변경 후 방식:**
    - 기존에는 viewModel마다 url이 직접 적혀져있었는데 변경후에는 한곳에 모아서 변경했을때 관리하기가 편해졌다.

### **📸 스크린샷 (UI 변경이 있을 경우)**
![image](https://github.com/user-attachments/assets/0eb34c8d-193f-4171-82b5-0bc41af9915f)
Config파일일안에 URL을 지정해준 모습
![image](https://github.com/user-attachments/assets/2c379742-79f5-4206-9252-71f6e9c3eab6)
Info파일에서 URL을 지정해준 모습

