### PR TITLE
🚀 [Feature] #11 - 유저 정보 수정 기능

### DIFF
--- a/walkingGO.xcodeproj/xcuserdata/bagseongmin.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/walkingGO.xcodeproj/xcuserdata/bagseongmin.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "90E72F28-20D5-419F-A648-B144625BAA98"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "58FFD9FE-9CA8-44F8-BC5C-69BC747FDC9A"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "walkingGO/Source/Features/Menu/MyPage/editProfilView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "8"
+            endingLineNumber = "8"
+            landmarkName = "unknown"
+            landmarkType = "0">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/walkingGO/Source/Features/Goal/GoalView.swift
+++ b/walkingGO/Source/Features/Goal/GoalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SDWebImageSwiftUI
 
 struct GoalView: View {
-    @State private var value: Double = 3.0
+    @StateObject var viewModel = GoalViewModel()
     @EnvironmentObject var pathModel: PathModel
     
     var body: some View {
@@ -45,15 +45,17 @@ struct GoalView: View {
             .font(AppFont.PretendardSemiBold(size: 13))
             .foregroundStyle(.textFieldTitle)
             
-            CustomSlider(value: $value, range: 0...5, step: 0.5)
+            CustomSlider(value: $viewModel.value, range: 0...5, step: 0.5)
                 .frame(height: 10)
                 .padding(.horizontal, 20)
             
             Spacer()
                 .frame(height: 40)
-            Text(String(format: "%.1f km", value))
+            
+            Text(String(format: "%.1f km", viewModel.value))
                 .font(AppFont.PretendardSemiBold(size: 23))
                 .padding(.top, 10)
+            
             Spacer()
                 .frame(height: 40)
             
@@ -61,11 +63,20 @@ struct GoalView: View {
                 title: "완료",
                 action: {
                     //백엔드 유저 목표 수정 요청
-                    pathModel.paths.removeLast()
+                    viewModel.changeUser()
                 },
                 width: 180
             )
             Spacer()
+        }
+        .alert(isPresented: $viewModel.showAlert){
+            return Alert(
+                title: Text("목표 수정 성공"),
+                message: Text("목표 수정에 성공하였습니다."),
+                dismissButton: .default(Text("확인")){
+                    pathModel.paths.removeLast()
+                }
+            )
         }
     }
 }

--- a/walkingGO/Source/Features/Goal/GoalViewModel.swift
+++ b/walkingGO/Source/Features/Goal/GoalViewModel.swift
@@ -1,0 +1,84 @@
+//
+//  GoalViewModel.swift
+//  walkingGO
+//
+//  Created by 박성민 on 6/10/25.
+//
+
+import Foundation
+import SwiftKeychainWrapper
+import Alamofire
+
+class GoalViewModel: ObservableObject{
+    @Published var value: Double = 3.0
+    @Published var showAlert: Bool = false
+    
+    private var userWeight: Double?
+    init() {
+        self.userWeight = nil
+        getUser()
+    }
+    
+    func getUser() {
+        guard let token = KeychainWrapper.standard.string(forKey: "authorization") else {
+            print("토큰이 없습니다")
+            return
+        }
+        
+        let url = Config.url
+        
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(token)"
+        ]
+        
+        AF.request("\(url)/api/users/me",
+                   method: .get,
+                   encoding: JSONEncoding.default,
+                   headers: headers)
+        .validate()
+        .responseDecodable(of: UserData.self){ response in
+            switch response.result {
+            case .success(let value):
+                self.userWeight = value.weightKg
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func changeUser() {
+        guard let token = KeychainWrapper.standard.string(forKey: "authorization") else {
+            print("토큰이 없습니다.")
+            return
+        }
+        
+        let url = Config.url
+        
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(token)"
+        ]
+        
+        let weight = userWeight ?? 0.0
+            
+        let parameters: [String: Any] = [
+            "weightKg": weight,
+            "targetDistanceKm": value
+        ]
+        
+        AF.request("\(url)/api/users/me/profile",
+                   method: .put,
+                   parameters: parameters,
+                   encoding: JSONEncoding.default,
+                   headers: headers)
+        .validate()
+        .responseDecodable(of: UserData.self){ response in
+            switch response.result{
+            case .success(let value):
+                print(value)
+                self.showAlert = true
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+}

--- a/walkingGO/Source/Features/Menu/MyPage/EditProfileView.swift
+++ b/walkingGO/Source/Features/Menu/MyPage/EditProfileView.swift
@@ -1,0 +1,82 @@
+//
+//  EditProfileView.swift
+//  walkingGO
+//
+//  Created by 박성민 on 6/7/25.
+//
+
+import SwiftUI
+
+struct EditProfileView: View {
+    @EnvironmentObject var pathModel: PathModel
+    @StateObject var viewModel = EditProfileViewModel()
+    
+    var body: some View {
+        VStack{
+            editHeader
+            
+            Spacer()
+            
+            editBody
+            
+            Spacer()
+        }
+        .alert(isPresented: $viewModel.showAlert){
+            return Alert(
+                title: Text("몸무게 변경 성공"),
+                message: Text("몸무게 변경에 성공했습니다."),
+                dismissButton: .default(Text("확인")){
+                    pathModel.paths.removeLast()
+                })
+        }
+    }
+    
+    var editHeader: some View {
+        ZStack{
+            Rectangle()
+                .frame(height: 50)
+                .foregroundStyle(.customBlue)
+                .background(.customBlue)
+            HStack{
+                Spacer()
+                    .frame(width:20)
+                Image(systemName: "chevron.left")
+                    .foregroundStyle(.white)
+                    .onTapGesture {
+                        pathModel.paths.removeLast()
+                    }
+                Spacer()
+            }
+        }
+    }
+    
+    var editBody: some View {
+        VStack(spacing:20){
+            ZStack{
+                Circle()
+                    .frame(width: 200, height: 200)
+                    .foregroundStyle(.yellow)
+                Image("character")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 150)
+            }
+            
+            CustomTextField(
+                text: $viewModel.userWeight,
+                title: "몸무게"
+            )
+            
+            CustomButton(
+                title: "수정하기",
+                action: {
+                    viewModel.changeUser()
+                }
+            )
+        }
+    }
+}
+
+#Preview {
+    EditProfileView()
+}

--- a/walkingGO/Source/Features/Menu/MyPage/EditProfileViewModel.swift
+++ b/walkingGO/Source/Features/Menu/MyPage/EditProfileViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  EditProfileViewModel.swift
+//  walkingGO
+//
+//  Created by 박성민 on 6/7/25.
+//
+
+import Foundation
+import SwiftKeychainWrapper
+import Alamofire
+
+class EditProfileViewModel: ObservableObject{
+    @Published var userWeight: String = ""
+    @Published var showAlert: Bool = false
+    
+    private var targetDistanceKm: Double?
+    
+    
+    init() {
+        self.targetDistanceKm = nil
+        getuser()
+    }
+    
+    func getuser() {
+        guard let token = KeychainWrapper.standard.string(forKey: "authorization") else {
+            print("토큰이 없습니다")
+            return
+        }
+        
+        let url = Config.url
+        
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(token)"
+        ]
+        
+        AF.request("\(url)/api/users/me",
+                   method: .get,
+                   encoding: JSONEncoding.default,
+                   headers: headers)
+        .validate()
+        .responseDecodable(of: UserData.self){ response in
+            switch response.result {
+            case .success(let value):
+                self.targetDistanceKm = value.targetDistanceKm
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func changeUser() {
+        guard let token = KeychainWrapper.standard.string(forKey: "authorization") else {
+            print("토큰이 없습니다.")
+            return
+        }
+        
+        guard let weight = Double(userWeight), weight > 0 else {
+            print("weight가 실수가 아닙니다.")
+            return
+        }
+        
+        let url = Config.url
+        
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(token)"
+        ]
+        
+        let targetDistance = targetDistanceKm ?? 0.0
+            
+        let parameters: [String: Any] = [
+            "weightKg": userWeight,
+            "targetDistanceKm": targetDistance
+        ]
+        
+        AF.request("\(url)/api/users/me/profile",
+                   method: .put,
+                   parameters: parameters,
+                   encoding: JSONEncoding.default,
+                   headers: headers)
+        .validate()
+        .responseDecodable(of: UserData.self){ response in
+            switch response.result{
+            case .success(let value):
+                print(value)
+                self.showAlert = true
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+}

--- a/walkingGO/Source/Features/Menu/MyPage/MyPageView.swift
+++ b/walkingGO/Source/Features/Menu/MyPage/MyPageView.swift
@@ -35,20 +35,18 @@ struct MyPageView: View {
 }
 
 fileprivate struct MyPageViewHeader: View {
+    @EnvironmentObject var pathModel: PathModel
     var body: some View{
         VStack{
             HStack{
                 Spacer()
-                Image(systemName: "bell.fill")
+                Image(systemName: "gearshape.fill")
                     .foregroundStyle(.white)
                     .scaledToFit()
                     .frame(width: 30)
-                    .overlay(
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: 6, height: 6)
-                            .offset(x: -6, y: 2), alignment: .topTrailing
-                    )
+                    .onTapGesture {
+                        pathModel.paths.append(.editProfil)
+                    }
                 Spacer()
                     .frame(width: 20)
             }
@@ -123,4 +121,5 @@ fileprivate struct mapRouteView : View {
 
 #Preview {
     MyPageView()
+        .environmentObject(PathModel())
 }

--- a/walkingGO/Source/Features/Root/RootView.swift
+++ b/walkingGO/Source/Features/Root/RootView.swift
@@ -40,12 +40,14 @@ struct RootView: View {
                     MapView()
                         .navigationBarHidden(true)
                         .navigationBarBackButtonHidden()
-                    
                 case .goal:
                     GoalView()
                         .navigationBarBackButtonHidden()
                 case .secretTeam:
                     SecretTeamJoinView()
+                        .navigationBarBackButtonHidden()
+                case .editProfil:
+                    EditProfileView()
                         .navigationBarBackButtonHidden()
                 }
             }

--- a/walkingGO/Source/Model/Path/PathType.swift
+++ b/walkingGO/Source/Model/Path/PathType.swift
@@ -15,4 +15,5 @@ enum PathType: Hashable{
     case map
     case goal
     case secretTeam
+    case editProfil
 }

--- a/walkingGO/Source/Model/User/UserData.swift
+++ b/walkingGO/Source/Model/User/UserData.swift
@@ -1,0 +1,15 @@
+//
+//  UserData.swift
+//  walkingGO
+//
+//  Created by 박성민 on 6/8/25.
+//
+
+import Foundation
+
+struct UserData: Codable {
+    let id: Int
+    let username: String
+    let weightKg: Double?
+    let targetDistanceKm: Double?
+}


### PR DESCRIPTION
### **🔹 작업 내용**

- 유저 몸무게 수정 기능을 완성했습니다.
- 유저 목표 수정 기능을 완성했습니다.

### **🔍 변경 사항 상세**

- **몸무게 수정 기능**
    - MyPageView 안에서 설정 아이콘을 클릭하면 몸무게 수정 뷰에 들어갈수 있습니다.
    - 현재 백엔드가 몸무게와 목표가 같이 묶여있기 때문에 몸무게 수정뷰에서도 현재 유저의 목표를 받아오는 기능을 구현했습니다.
    - 몸무게가 실수일때만 수정 요청을 보냅니다. 
- **목표 수정 기능**
    - 목표 수정 기능도 똑같이 몸무게 값을 ViewModel이 로딩되었을때 받아와서 저장합니다.
    - value값을 원래 뷰에서 관리했는데 ViewModel로 넘겼습니다.
    - 그리고 요청을 보내고 반환이 오면 alert를 통해 뷰에서 나가게 하였습니다.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**

- **현재까지는 백엔드를 지금 그대로 쓰고있지만 수정이 된다면 다시 고쳐야 합니다.**
- **경로 기록 부분에서 몸무게를 현재는 기본값을 쓰고 있지만 유저가 몸무게 데이터가 없다면 기본값을 쓰고 아니라면 몸무게 값으로 칼로리를 계산하게 해야합니다.**
- **alert이 성공 로직만 있고 실패 로직이 없습니다.**