### PR TITLE
🚀[Fix]  #13 - Km Formating

### DIFF
--- a/walkingGO/Source/Features/Menu/Rank/RankView.swift
+++ b/walkingGO/Source/Features/Menu/Rank/RankView.swift
@@ -75,7 +75,7 @@ struct RankView: View {
                                     Text(team.name)
                                         .font(AppFont.PretendardBold(size: 14))
                                         .multilineTextAlignment(.center)
-                                    Text("\(team.totalDistanceKm)")
+                                    Text(String(format: "%.2f",team.totalDistanceKm))
                                         .font(AppFont.PretendardSemiBold(size: 12))
                                         .multilineTextAlignment(.center)
                                 }
@@ -106,7 +106,7 @@ struct RankView: View {
                             
                             Spacer()
                             
-                            Text("\(team.totalDistanceKm)")
+                            Text(String(format: "%.2f",team.totalDistanceKm))
                                 .font(AppFont.PretendardSemiBold(size: 13))
                                 .foregroundStyle(.customBlue)
                             

--- a/walkingGO/Source/Features/Menu/Team/TeamView.swift
+++ b/walkingGO/Source/Features/Menu/Team/TeamView.swift
@@ -88,7 +88,7 @@ struct TeamView: View {
                                         
                                         Spacer()
                                         
-                                        Text("\(member.totalDistanceKm)")
+                                        Text(String(format: "%.2f",member.totalDistanceKm))
                                             .font(AppFont.PretendardSemiBold(size: 13))
                                         
                                         Spacer()


### PR DESCRIPTION
### **🔹 작업 내용**

- KM가 0.0000이런식으로 표시되는걸 소수점 둘째자리까지 표시되게 고쳤습니다.

### **🔍 변경 사항 상세**

- **포매팅**
    - String(format: "%.2f", [변수]) 를 통해 둘째자리까지만 표시되게 고쳤습니다.